### PR TITLE
fix: windows  路径

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ When you use `web-dev-server`, maybe you wanner do something at everytime webpac
 
   ```bash
     # webpack.config.js
-    const Upload = require('webpack-asset-upload-plugin')
+    const Upload = require('webpack-assets-upload-plugin')
 
     ...
     plugins: [
@@ -35,7 +35,7 @@ When you use `web-dev-server`, maybe you wanner do something at everytime webpac
 
   ```bash
     # webpack.config.js
-    const Upload = require('webpack-asset-upload-plugin')
+    const Upload = require('webpack-assets-upload-plugin')
 
     ...
     plugins: [

--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ class UploadPlugin {
         sftp.connect(options).then(() => {
           let tasks = fileArr.map(({filename, source}) => {
             let buffer = Buffer.from(source)
-            return sftp.put(buffer, path.resolve(remotePath, filename))
+            return sftp.put(buffer, path.join(remotePath, filename).split(path.sep).join('/'))
                 .then(() => {
                   console.log(emoji.get('smiley'), chalk.green(`文件: ${filename} 已上传至服务器下${remotePath}`))
                 }).catch((err) => {


### PR DESCRIPTION
Windows下使用的时候上传不成功

1. 应该 路径分隔符有问题
2. `webpack`输出的`filename`是带有盘符的，`path.resolve`之后就变成了`D:\xxx\xxx`了